### PR TITLE
Added writeup for uguu.org

### DIFF
--- a/writeups.html
+++ b/writeups.html
@@ -79,6 +79,10 @@
 	    <td>B$ L$ B$ v$ v$ L$ B$ v$ v$</td>
 	    <td><a href="https://github.com/J-ai-trouve-que-le-hot-dog/2024">https://github.com/J-ai-trouve-que-le-hot-dog/2024</a></td>
 	  </tr>
+	  <tr>
+	    <td>uguu.org</td>
+	    <td><a href="https://github.com/uguu-org/icfpc2024">https://github.com/uguu-org/icfpc2024</a></td>
+	  </tr>
 	</tbody>
       </table>
     </div>


### PR DESCRIPTION
Added link to writeup for uguu.org

By the way, the Discord invite link did not work and still doesn't work.  I wish there is at least an email fallback in the future if we need to reach out to the organizers.